### PR TITLE
Add RuboCop GitHub error formatter to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
         run: bundle install
 
       - name: Lint and check formatting with Rubocop
-        run: bundle exec rubocop
+        run: bundle exec rubocop --format github
 
   text:
     name: Lint and format text

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@
 
 source 'https://rubygems.org'
 
-gem 'rubocop'
+gem 'rubocop', '~> 1.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rubocop
+  rubocop (~> 1.2)
 
 BUNDLED WITH
-   2.0.1
+   2.1.4


### PR DESCRIPTION
Introduced with bump to RuboCop 1.2.0 in #124.