### PR TITLE
Update Audit GitHub Actions workflow

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -12,6 +12,7 @@ name: Audit
 jobs:
   js:
     name: Audit JS Dependencies
+    if: true
     runs-on: ubuntu-latest
 
     steps:
@@ -23,3 +24,44 @@ jobs:
 
       - name: npm audit
         run: npm audit
+
+  ruby:
+    name: Audit Ruby Dependencies
+    if: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ".ruby-version"
+          bundler-cache: true
+
+      - name: bundler-audit
+        run: bundle exec bundle-audit check --update
+
+  rust:
+    name: Audit Rust Dependencies
+    if: false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup cargo-deny
+        run: |
+          release_base="https://github.com/EmbarkStudios/cargo-deny/releases/download"
+          version="0.9.1"
+          cargo_deny_tarball="$release_base/$version/cargo-deny-$version-x86_64-unknown-linux-musl.tar.gz"
+          echo "Downloading cargo-deny $version from $cargo_deny_tarball."
+          curl -sL "$cargo_deny_tarball" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
+
+      - name: cargo-deny version
+        run: cargo-deny --version
+
+      - name: Run cargo-deny
+        run: cargo-deny check --show-stats

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@
 
 source 'https://rubygems.org'
 
+gem 'bundler-audit', '~> 0.8', require: false
 gem 'rubocop', '~> 1.18', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    bundler-audit (0.8.0)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -20,13 +23,15 @@ GEM
     rubocop-ast (1.8.0)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
+    thor (1.1.0)
     unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler-audit (~> 0.8)
   rubocop (~> 1.18)
 
 BUNDLED WITH
-   2.1.4
+   2.2.22


### PR DESCRIPTION
Managed by Terraform.

The cargo-deny version is 0.9.1.