### PR TITLE
Add GitHub Actions workflow to run markdown-link-check

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -1,0 +1,16 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "img.shields.io"
+    }
+  ],
+  "replacementPatterns": [],
+  "httpHeaders": [
+    {
+      "urls": ["https://crates.io"],
+      "headers": {
+        "Accept": "text/html"
+      }
+    }
+  ]
+}

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,0 +1,34 @@
+---
+"on":
+  push:
+    branches:
+      - trunk
+    paths:
+      - .github/markdown-link-check.json
+      - .github/workflows/markdown-link-check.yaml
+      - "**/*.md"
+  pull_request:
+    branches:
+      - trunk
+    paths:
+      - .github/markdown-link-check.json
+      - .github/workflows/markdown-link-check.yaml
+      - "**/*.md"
+  schedule:
+    - cron: "0 0 * * TUE"
+name: Markdown Links Check
+jobs:
+  check-links:
+    name: Check links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Check for broken links in markdown files
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          config-file: ".github/markdown-link-check.json"
+          folder-path: "."

--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@
 [![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
 [![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
 
-[Artichoke](https://github.com/artichoke/artichoke) is a Ruby implementation
-written in Rust and Ruby.
+[Artichoke] is a Ruby implementation written in Rust and Ruby.
 
-You can [try Artichoke in your browser](https://artichoke.run). The
-[Artichoke Playground](https://github.com/artichoke/playground) runs a
-[WebAssembly](https://webassembly.org/) build of Artichoke.
+[artichoke]: https://github.com/artichoke/artichoke
+
+You can [try Artichoke in your browser]. The [Artichoke Playground] runs a
+[WebAssembly] build of Artichoke.
+
+[try artichoke in your browser]: https://artichoke.run
+[artichoke playground]: https://github.com/artichoke/playground
+[webassembly]: https://webassembly.org/
 
 <p align="center">
   <a href="https://artichoke.run">
@@ -27,8 +31,9 @@ needs help on issues labeled
 
 ## 2019 – Artichoke Is a Ruby Made With Rust
 
-Talk:
-[Building a Ruby: Artichoke is a Ruby Made with Rust](https://rubyconf.org/program#session-854)  
+Talk: [Building a Ruby: Artichoke is a Ruby Made with Rust][2019-talk]  
 Track: Ruby Implementations  
 Date: Wednesday, November 20, 2019 at 10:30AM CST  
 Deck: <https://artichoke.github.io/rubyconf/2019>
+
+[2019-talk]: https://www.youtube.com/watch?v=QMni48MBqFw

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
 [![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
 
-[Artichoke](https:/github.com/artichoke/artichoke) is a Ruby implementation
+[Artichoke](https://github.com/artichoke/artichoke) is a Ruby implementation
 written in Rust and Ruby.
 
 You can [try Artichoke in your browser](https://artichoke.run). The

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "dev:open": "webpack serve --mode development --open",
     "fmt": "npx prettier --write \"**/*\"",
     "lint": "npx eslint .",
-    "lint:fix": "npx eslint --fix ."
+    "lint:fix": "npx eslint --fix .",
+    "release:markdown_link_check": "find . -name '*.md' -and -not -path '*/node_modules/*' | sort | xargs -n1 npx markdown-link-check --config .github/markdown-link-check.json"
   }
 }


### PR DESCRIPTION
Artichoke already incorporates this tool in the `Rakefile` as the
`release:markdown_link_check` task, but it is slow and doesn't get
regularly run.

Incorporate this into CI such that links are checked on every PR that
touches markdown files and on a weekly cron with the same cadence as the
audit workflow.