### PR TITLE
Load `deck2019.js` script with `defer`

### DIFF
--- a/src/2019/deck.js
+++ b/src/2019/deck.js
@@ -9,39 +9,37 @@ import "highlight.js/styles/monokai.css";
 
 import "./deck.scss";
 
-document.addEventListener("DOMContentLoaded", () => {
-  Reveal.addEventListener("ready", () => {
-    const revealContainer = document.getElementById("js-reveal-container");
-    const artichokeChrome = document.getElementById("js-artichoke-chrome");
-    revealContainer.appendChild(artichokeChrome);
-    artichokeChrome.classList.add("is-visible");
+Reveal.addEventListener("ready", () => {
+  const revealContainer = document.getElementById("js-reveal-container");
+  const artichokeChrome = document.getElementById("js-artichoke-chrome");
+  revealContainer.appendChild(artichokeChrome);
+  artichokeChrome.classList.add("is-visible");
 
-    window.twttr = ((d, s, id) => {
-      const fjs = d.getElementsByTagName(s)[0];
-      const t = window.twttr || {};
-      if (d.getElementById(id)) return t;
-      const js = d.createElement(s);
-      js.id = id;
-      js.src = "https://platform.twitter.com/widgets.js";
-      fjs.parentNode.insertBefore(js, fjs);
+  window.twttr = ((d, s, id) => {
+    const fjs = d.getElementsByTagName(s)[0];
+    const t = window.twttr || {};
+    if (d.getElementById(id)) return t;
+    const js = d.createElement(s);
+    js.id = id;
+    js.src = "https://platform.twitter.com/widgets.js";
+    fjs.parentNode.insertBefore(js, fjs);
 
-      t._e = [];
-      t.ready = (f) => t._e.push(f);
+    t._e = [];
+    t.ready = (f) => t._e.push(f);
 
-      return t;
-    })(document, "script", "twitter-wjs");
-  });
+    return t;
+  })(document, "script", "twitter-wjs");
+});
 
-  Reveal.initialize({
-    width: 960,
-    controls: false,
-    progress: true,
-    slideNumber: false,
-    history: true,
-    keyboard: true,
-    overview: true,
-    transition: "slide",
-    transitionSpeed: "default",
-    plugins: [],
-  });
+Reveal.initialize({
+  width: 960,
+  controls: false,
+  progress: true,
+  slideNumber: false,
+  history: true,
+  keyboard: true,
+  overview: true,
+  transition: "slide",
+  transitionSpeed: "default",
+  plugins: [],
 });

--- a/src/2019/index.html
+++ b/src/2019/index.html
@@ -424,6 +424,6 @@ ubuntu@ip-172-31-21-76:~$ precise-time 50 $HOME/bin/artichoke bench_ary_sparse.r
         </a>
       </div>
     </div>
-    <script type="module" src="../deck2019.bundle.js"></script>
+    <script defer type="module" src="../deck2019.bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
`script` tags loaded with the `defer` attribute download in parallel to
the DOM being built but are executed after the DOM is fully constructed.

This change speeds up the page by letting the script be downloaded in
parallel and allows removing the `DOMContentLoaded` event listener for
setting up Reveal; instead the code can just be executed directly by the
loaded JavaScript module.

I learned this here: https://github.com/artichoke/www.artichokeruby.org/pull/452#discussion_r769008784