### PR TITLE
Upgrade eta to ^2.0.0 to address CVE-2023-23630

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@minify-html/node": "^0.10.3",
         "esbuild": "^0.16.12",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "highlight.js": "^11.7.0",
         "marked": "^4.2.5",
         "sass": "^1.57.1"
@@ -502,9 +502,9 @@
       }
     },
     "node_modules/eta": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/eta/-/eta-1.12.3.tgz",
-      "integrity": "sha512-qHixwbDLtekO/d51Yr4glcaUJCIjGVJyTzuqV4GPlgZo1YpgOKG+avQynErZIYrfM6JIJdtiG2Kox8tbb+DoGg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.0.tgz",
+      "integrity": "sha512-NqE7S2VmVwgMS8yBxsH4VgNQjNjLq1gfGU0u9I6Cjh468nPRMoDfGdK9n1p/3Dvsw3ebklDkZsFAnKJ9sefjBA==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@minify-html/node": "^0.10.3",
     "esbuild": "^0.16.12",
-    "eta": "^1.12.3",
+    "eta": "^2.0.0",
     "highlight.js": "^11.7.0",
     "marked": "^4.2.5",
     "sass": "^1.57.1"


### PR DESCRIPTION
All eta versions less than 2.0.0 are vulnerable to an XSS attack when used in conjunction with express. The Artichoke rubyconf decks do not use eta in this way.

- CVE-2023-23630
- https://github.com/advisories/GHSA-xrh7-m5pp-39r6

Remediation steps:

```
npm i -D eta@^2.0.0
```

See also:

- https://github.com/artichoke/playground/pull/984
- https://github.com/artichoke/www.artichokeruby.org/pull/549

Obsoletes:

- https://github.com/artichoke/rubyconf/pull/456